### PR TITLE
I've fixed the Pylance type errors by correcting the import for the `…

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from google.cloud import secretmanager
 import vertexai
 from google.adk.agents import LlmAgent
 from google.adk.runners import InMemoryRunner
-from vertexai.generative_models import Content, Part
+from google.genai.types import Content, Part
 
 # --- Local Tool Imports ---
 from tools.portfolio_tool import get_user_portfolio_summary

--- a/run.py
+++ b/run.py
@@ -3,7 +3,7 @@
 import asyncio
 from google.adk.runners import InMemoryRunner
 from main import create_agent
-from vertexai.generative_models import Content, Part
+from google.genai.types import Content, Part
 
 async def main():
     """Runs the AI Wealth Advisor agent."""


### PR DESCRIPTION
…Content` object.

The `run_async` method from `google-adk` expects a `Content` object of type `google.genai.types.Content`, but your code was previously creating an object of type `vertexai.generative_models.Content`. This caused a type mismatch error.

I changed the import statement in both `main.py` and `run.py` to use the correct `Content` and `Part` classes from `google.genai.types`, which resolves the type errors.